### PR TITLE
Update Infiniti Q70 generations: Add references and standard README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
-# Model make
+# Infiniti Q70
+
+This repository contains signal set configurations for the Infiniti Q70, organized by model year and version. The files are structured to allow for easy differentiation between model generations and other vehicle parameters, ensuring accurate signal mapping for each version of the Infiniti Q70.
+
+## Contributing
+
+Contributions are welcome! If you would like to add support for additional model years or other configurations, please open an issue or submit a pull request.
+
+1. Fork the repository
+2. Create a new branch for your changes
+3. Commit your changes and open a pull request with a detailed description
+
+## Issues
+
+If you encounter any issues or would like to discuss improvements, please feel free to open an issue. We encourage collaboration and appreciate feedback to make the repository as accurate and useful as possible.
 

--- a/generations.yaml
+++ b/generations.yaml
@@ -1,3 +1,7 @@
+references:
+  - "https://en.wikipedia.org/wiki/Infiniti_Q70"
+  - "https://en.wikipedia.org/wiki/Infiniti_M"
+
 generations:
   - name: "First Generation (as Infiniti M, Y51)"
     start_year: 2011


### PR DESCRIPTION
- Added Wikipedia references for Infiniti Q70 and Infiniti M articles
- Updated README.md with standard vehicle template
- Verified generational data against Wikipedia confirms:
  * Fourth generation M (Y51) produced 2011-2014
  * Renamed to Q70 for 2014-2019 model years on same platform
